### PR TITLE
Fix collisions when jumping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.exe
 **/.DS_Store
+CMakeLists.txt
 
 cmake-build-debug
 .idea

--- a/src/controller.c
+++ b/src/controller.c
@@ -90,13 +90,17 @@ void UpdateController(Controller *controller)
     bool blockInLeft  = isColliderInDirection(GetPlayerBlockPos(controller), (Vector3){ 0, 0,-1}, controller->world);
 
     if (GetWorldCubeV(controller->world, Vector3Add(GetPlayerBlockPos(controller), (Vector3){0,-2, 0})) == 1)
-        movement = Vector3Subtract(movement, getForceToDirection((Vector3){ 0, 1, 0}, movement));
+    {
+        movement = Vector3Subtract(movement, getForceToDirection((Vector3) {0, 1, 0}, movement));
+        controller->onGround = true;
+    }
     else
     {
         blockInFront = isColliderInDirectionEx(GetPlayerBlockPos(controller), (Vector3){ 1, 0, 0}, controller->world);
         blockInBack  = isColliderInDirectionEx(GetPlayerBlockPos(controller), (Vector3){-1, 0, 0}, controller->world);
         blockInRight = isColliderInDirectionEx(GetPlayerBlockPos(controller), (Vector3){ 0, 0, 1}, controller->world);
         blockInLeft  = isColliderInDirectionEx(GetPlayerBlockPos(controller), (Vector3){ 0, 0,-1}, controller->world);
+        controller->onGround = false;
     }
 
     BoundingBox boundingBoxPlayer = {(Vector3){(controller->cam.position.x - 0.5f),

--- a/src/controller.c
+++ b/src/controller.c
@@ -1,5 +1,3 @@
-// raycraft (c) Nikolas Wipper 2020
-
 #include "controller.h"
 
 #include <raymath.h>

--- a/src/controller.c
+++ b/src/controller.c
@@ -61,27 +61,6 @@ void UpdateController(Controller *controller)
 
     //controller->rotation.x = Clamp(controller->rotation.x, -40, 40);
 
-    // -------------------- Movement stuff --------------------
-
-    float direction[] = { IsKeyDown(FORWARD_KEY),
-                          IsKeyDown(BACKWARD_KEY),
-                          IsKeyDown(RIGHT_KEY),
-                          IsKeyDown(LEFT_KEY)};
-
-    movement = (Vector3){0, movement.y + GetFrameTime() * -0.5, 0};
-    movement.x = (sinf(controller->rotation.x)*direction[1] -
-                  sinf(controller->rotation.x)*direction[0] -
-                  cosf(controller->rotation.x)*direction[3] +
-                  cosf(controller->rotation.x)*direction[2])/PLAYER_MOVEMENT_SENSITIVITY;
-
-    movement.z = (cosf(controller->rotation.x)*direction[1] -
-                  cosf(controller->rotation.x)*direction[0] +
-                  sinf(controller->rotation.x)*direction[3] -
-                  sinf(controller->rotation.x)*direction[2])/PLAYER_MOVEMENT_SENSITIVITY;
-
-    if (IsKeyPressed(KEY_SPACE))
-        movement.y = 0.15f;
-
     // -------------------- Collision stuff --------------------
 
     bool blockInFront = isColliderInDirection(GetPlayerBlockPos(controller), (Vector3){ 1, 0, 0}, controller->world);
@@ -95,12 +74,14 @@ void UpdateController(Controller *controller)
         controller->onGround = true;
     }
     else
+        controller->onGround = false;
+
+    if (!controller->onGround)
     {
         blockInFront = isColliderInDirectionEx(GetPlayerBlockPos(controller), (Vector3){ 1, 0, 0}, controller->world);
         blockInBack  = isColliderInDirectionEx(GetPlayerBlockPos(controller), (Vector3){-1, 0, 0}, controller->world);
         blockInRight = isColliderInDirectionEx(GetPlayerBlockPos(controller), (Vector3){ 0, 0, 1}, controller->world);
         blockInLeft  = isColliderInDirectionEx(GetPlayerBlockPos(controller), (Vector3){ 0, 0,-1}, controller->world);
-        controller->onGround = false;
     }
 
     BoundingBox boundingBoxPlayer = {(Vector3){(controller->cam.position.x - 0.5f),
@@ -147,6 +128,27 @@ void UpdateController(Controller *controller)
     controller->cam.position.y += movement.y;
 
     controller->cam.position.z += movement.z / PLAYER_MOVEMENT_SENSITIVITY;
+
+    // -------------------- Movement stuff --------------------
+
+    float direction[] = { IsKeyDown(FORWARD_KEY),
+                          IsKeyDown(BACKWARD_KEY),
+                          IsKeyDown(RIGHT_KEY),
+                          IsKeyDown(LEFT_KEY)};
+
+    movement = (Vector3){0, movement.y + GetFrameTime() * -0.5, 0};
+    movement.x = (sinf(controller->rotation.x)*direction[1] -
+                  sinf(controller->rotation.x)*direction[0] -
+                  cosf(controller->rotation.x)*direction[3] +
+                  cosf(controller->rotation.x)*direction[2])/PLAYER_MOVEMENT_SENSITIVITY;
+
+    movement.z = (cosf(controller->rotation.x)*direction[1] -
+                  cosf(controller->rotation.x)*direction[0] +
+                  sinf(controller->rotation.x)*direction[3] -
+                  sinf(controller->rotation.x)*direction[2])/PLAYER_MOVEMENT_SENSITIVITY;
+
+    if (IsKeyPressed(KEY_SPACE) && controller->onGround)
+        movement.y = 0.15f;
 
     // -------------------- Retarget stuff --------------------
 

--- a/src/controller.h
+++ b/src/controller.h
@@ -18,6 +18,7 @@ typedef struct Controller
     struct Vector3 rotation;
     struct Camera3D cam;
     int *world;
+    bool onGround;
 } Controller;
 
 void InitializeController(Controller *controller, int *world);

--- a/src/controller.h
+++ b/src/controller.h
@@ -1,5 +1,3 @@
-// raycraft (c) Nikolas Wipper 2020
-
 #ifndef RAYCRAFT_CONTROLLER_H
 #define RAYCRAFT_CONTROLLER_H
 

--- a/src/util.c
+++ b/src/util.c
@@ -1,5 +1,3 @@
-// raycraft (c) Nikolas Wipper 2020
-
 #include "util.h"
 
 float roundHalf(float f)

--- a/src/util.h
+++ b/src/util.h
@@ -1,5 +1,3 @@
-// raycraft (c) Nikolas Wipper 2020
-
 #ifndef RAYCRAFT_UTIL_H
 #define RAYCRAFT_UTIL_H
 

--- a/src/world/perlin.h
+++ b/src/world/perlin.h
@@ -1,5 +1,3 @@
-// raycraft (c) Nikolas Wipper 2020
-
 #ifndef RAYCRAFT_PERLIN_H
 #define RAYCRAFT_PERLIN_H
 

--- a/src/world/worldgeneration.h
+++ b/src/world/worldgeneration.h
@@ -1,5 +1,3 @@
-// raycraft (c) Nikolas Wipper 2020
-
 #ifndef RAYCRAFT_WORLDGENERATION_H
 #define RAYCRAFT_WORLDGENERATION_H
 

--- a/src/world/worldmodel.h
+++ b/src/world/worldmodel.h
@@ -1,5 +1,3 @@
-// raycraft (c) Nikolas Wipper 2020
-
 #ifndef RAYCRAFT_WORLDMODEL_H
 #define RAYCRAFT_WORLDMODEL_H
 


### PR DESCRIPTION
Collisions are a pretty complicated topic, but I will try to keep it as simple as possible.
Before this patch, collisions were only checked for the two main blocks i.e. the block the camera is in, and the one below, plus an offset into each north, east, south and west. Now, when the player jumps, it is possible for them to be in three blocks at the same time. This one block is located two blocks below the camera block, and as the game only checks one block below the camera it doesn't consider these blocks for collisions and therefore allows the player to jump into blocks from the side. This fix checks if the player is on the ground, data we can get from a previous collision, and if they are not, checks this third block as well.

This change also comes with a handy `onGround` field. I couldn't resist adding a check for jumping using it ;)